### PR TITLE
<解約企業データ削除処理> 削除進捗詳細画面の作成

### DIFF
--- a/lib/association_data_deleter/views/deletion_jobs/show.html.erb
+++ b/lib/association_data_deleter/views/deletion_jobs/show.html.erb
@@ -1,1 +1,91 @@
 <h1>削除進捗詳細情報</h1>
+
+<div class="card mb-4">
+  <div class="card-body">
+    <table class="table table-bordered">
+      <tbody>
+        <tr>
+          <th style="width: 200px;">ID</th>
+          <td><%= @deletion_job.id %></td>
+        </tr>
+        <tr>
+          <th>削除対象のトップテーブル</th>
+          <td><%= @deletion_job.target_type %></td>
+        </tr>
+        <tr>
+          <th>削除対象ID</th>
+          <td><%= @deletion_job.target_id %></td>
+        </tr>
+        <tr>
+          <th>削除進捗状態</th>
+          <td><%= @deletion_job.status %></td>
+        </tr>
+        <tr>
+          <th>削除進捗</th>
+          <td><%= @deletion_job.deleted_count %> / <%= @deletion_job.target_count %></td>
+        </tr>
+        <tr>
+          <th>準備フェーズジョブID</th>
+          <td><%= @deletion_job.prepare_aws_batch_job_id %></td>
+        </tr>
+        <tr>
+          <th>削除フェーズジョブID</th>
+          <td><%= @deletion_job.delete_aws_batch_job_id %></td>
+        </tr>
+        <tr>
+          <th>作成日</th>
+          <td><%= @deletion_job.created_at %></td>
+        </tr>
+        <tr>
+          <th>更新日</th>
+          <td><%= @deletion_job.updated_at %></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<h2>削除ジョブ詳細 (<%= @deletion_job.target_count %>件)</h2>
+
+<div class="table-responsive">
+  <table class="table table-striped table-bordered">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>テーブル名</th>
+        <th>table_name</th>
+        <th>foreign_key</th>
+        <th>polymorphic_id</th>
+        <th>polymorphic_type</th>
+        <th>status</th>
+        <th>削除数/対象数</th>
+        <th>開始時刻</th>
+        <th>完了時刻</th>
+        <th>最後に削除されたID</th>
+        <th>エラーメッセージ</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @deletion_job.deletion_job_details.each do |detail| %>
+        <tr>
+          <td><%= detail.id %></td>
+          <td><%= detail.table_name %></td>
+          <td><%= detail.table_name %></td>
+          <td><%= detail.foreign_key %></td>
+          <td><%= detail.polymorphic_id %></td>
+          <td><%= detail.polymorphic_type %></td>
+          <td><%= detail.status %></td>
+          <td><%= detail.deleted_count %> / <%= detail.target_count %></td>
+          <td><%= detail.started_at %></td>
+          <td><%= detail.finished_at %></td>
+          <td><%= detail.last_deleted_id %></td>
+          <td><%= detail.error_message %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+
+<div class="mt-3">
+  <%= link_to "戻る", association_data_deleter_engine.deletion_jobs_path, class: "btn btn-secondary" %>
+</div>

--- a/lib/association_data_deleter/views/deletion_jobs/show.html.erb
+++ b/lib/association_data_deleter/views/deletion_jobs/show.html.erb
@@ -52,7 +52,6 @@
     <thead>
       <tr>
         <th>ID</th>
-        <th>テーブル名</th>
         <th>table_name</th>
         <th>foreign_key</th>
         <th>polymorphic_id</th>
@@ -69,7 +68,6 @@
       <% @deletion_job.deletion_job_details.each do |detail| %>
         <tr>
           <td><%= detail.id %></td>
-          <td><%= detail.table_name %></td>
           <td><%= detail.table_name %></td>
           <td><%= detail.foreign_key %></td>
           <td><%= detail.polymorphic_id %></td>


### PR DESCRIPTION
## 概要
削除進捗の詳細確認が可能な画面を作成しました。


## テスト

- [x] `association_data_deleter/deletion_jobs/xx` にアクセスした時、showページが表示される

![スクリーンショット 2025-03-07 16 01 09](https://github.com/user-attachments/assets/6a57ed8d-c5af-42b2-b694-3bbd8d80d271)
