### PR TITLE
AWS Batchのジョブを送信するためのモデルを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,6 @@
 # AssociationDataDeleter
 
-TODO: Delete this and the text below, and describe your gem
-
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/association_data_deleter`. To experiment with that code, run `bin/console` for an interactive prompt.
-
 ## Installation
-
-TODO: Replace `UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG` with your gem name right after releasing it to RubyGems.org. Please do not do it earlier due to security reasons. Alternatively, replace this section with instructions to install your gem from git if you don't plan to release to RubyGems.org.
-
-Install the gem and add to the application's Gemfile by executing:
-
-```bash
-bundle add UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG
-```
-
-If bundler is not being used to manage dependencies, install the gem by executing:
-
-```bash
-gem install UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG
-```
 
 Add `deletion_jobs`, `deletion_job_details` tables to your database:
 
@@ -29,14 +11,19 @@ bundle exec rails db:migrate
 
 ## Usage
 
-TODO: Write usage instructions here
+Create association data YAML file.
+```bash
+bundle exec rake association_data_deleter:generate_relations_yaml[top_table_name,product_name]
+```
 
-## Development
+Set AWS Batch job queue and task definition.
+```ruby
+# config/initializers/association_data_deleter.rb
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
-
-## Contributing
-
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/association_data_deleter.
+AssociationDataDeleter.configure do |config|
+  config.preparation_job_queue = 'sample-preparation-job-queue'
+  config.preparation_job_definition = 'sample-preparation-job-definition'
+  config.execution_job_queue = 'sample-execution-job-queue'
+  config.execution_job_definition = 'sample-execution-job-definition'
+end
+```

--- a/association_data_deleter.gemspec
+++ b/association_data_deleter.gemspec
@@ -11,4 +11,5 @@ Gem::Specification.new do |spec|
   # Rails/ActiveRecordを使う場合
   spec.add_dependency "rails", ">= 5.1", "< 8.0"
   # など、必要に応じて依存ライブラリを追記
+  spec.add_dependency "aws-sdk-batch", "~> 1.111"
 end

--- a/association_data_deleter.gemspec
+++ b/association_data_deleter.gemspec
@@ -11,5 +11,5 @@ Gem::Specification.new do |spec|
   # Rails/ActiveRecordを使う場合
   spec.add_dependency "rails", ">= 5.1", "< 8.0"
   # など、必要に応じて依存ライブラリを追記
-  spec.add_dependency "aws-sdk-batch", "~> 1.111"
+  spec.add_dependency "aws-sdk-batch"
 end

--- a/lib/association_data_deleter.rb
+++ b/lib/association_data_deleter.rb
@@ -8,6 +8,7 @@ require_relative "association_data_deleter/railtie" if defined?(Rails)
 require_relative "association_data_deleter/models/deletion_job"
 require_relative "association_data_deleter/models/deletion_job_detail"
 require_relative "association_data_deleter/aws_batch"
+require_relative "association_data_deleter/config"
 
 module AssociationDataDeleter
   class Error < StandardError; end

--- a/lib/association_data_deleter.rb
+++ b/lib/association_data_deleter.rb
@@ -7,6 +7,7 @@ require_relative "association_data_deleter/railtie" if defined?(Rails)
 
 require_relative "association_data_deleter/models/deletion_job"
 require_relative "association_data_deleter/models/deletion_job_detail"
+require_relative "association_data_deleter/aws_batch"
 
 module AssociationDataDeleter
   class Error < StandardError; end

--- a/lib/association_data_deleter/aws_batch.rb
+++ b/lib/association_data_deleter/aws_batch.rb
@@ -6,11 +6,11 @@ module AssociationDataDeleter
       @client = Aws::Batch::Client.new(region: 'ap-northeast-1')
     end
 
-    def submit_preparation_job(job_name, job_queue, job_definition, deletion_job_id)
+    def submit_preparation_job(job_name, deletion_job_id)
       response = @client.submit_job({
         job_name: job_name,
-        job_queue: job_queue,
-        job_definition: job_definition,
+        job_queue: AssociationDataDeleter.config.preparation_job_queue,
+        job_definition: AssociationDataDeleter.config.preparation_job_definition,
         parameters: {
           'deletion_job_id' => deletion_job_id
         }

--- a/lib/association_data_deleter/aws_batch.rb
+++ b/lib/association_data_deleter/aws_batch.rb
@@ -7,10 +7,20 @@ module AssociationDataDeleter
     end
 
     def submit_preparation_job(job_name, deletion_job_id)
+      submit_job(job_name, AssociationDataDeleter.config.preparation_job_queue, AssociationDataDeleter.config.preparation_job_definition, deletion_job_id)
+    end
+
+    def submit_execution_job(job_name, deletion_job_id)
+      submit_job(job_name, AssociationDataDeleter.config.execution_job_queue, AssociationDataDeleter.config.execution_job_definition, deletion_job_id)
+    end
+
+    private
+
+    def submit_job(job_name, job_queue, job_definition, deletion_job_id)
       response = @client.submit_job({
         job_name: job_name,
-        job_queue: AssociationDataDeleter.config.preparation_job_queue,
-        job_definition: AssociationDataDeleter.config.preparation_job_definition,
+        job_queue: job_queue,
+        job_definition: job_definition,
         parameters: {
           'deletion_job_id' => deletion_job_id
         }

--- a/lib/association_data_deleter/aws_batch.rb
+++ b/lib/association_data_deleter/aws_batch.rb
@@ -5,5 +5,17 @@ module AssociationDataDeleter
     def initialize
       @client = Aws::Batch::Client.new(region: 'ap-northeast-1')
     end
+
+    def submit_preparation_job(job_name, job_queue, job_definition, deletion_job_id)
+      response = @client.submit_job({
+        job_name: job_name,
+        job_queue: job_queue,
+        job_definition: job_definition,
+        parameters: {
+          'deletion_job_id' => deletion_job_id
+        }
+      })
+      response.job_id
+    end
   end
 end

--- a/lib/association_data_deleter/aws_batch.rb
+++ b/lib/association_data_deleter/aws_batch.rb
@@ -1,0 +1,9 @@
+require 'aws-sdk-batch'
+
+module AssociationDataDeleter
+  class AwsBatch
+    def initialize
+      @client = Aws::Batch::Client.new(region: 'ap-northeast-1')
+    end
+  end
+end

--- a/lib/association_data_deleter/config.rb
+++ b/lib/association_data_deleter/config.rb
@@ -1,0 +1,25 @@
+module AssociationDataDeleter
+  class << self
+    def config
+      @config ||= Config.new
+    end
+
+    def configure
+      yield config
+    end
+  end
+
+  class Config
+    attr_accessor :preparation_job_queue,
+                  :preparation_job_definition,
+                  :execution_job_queue,
+                  :execution_job_definition
+
+    def initialize
+      @preparation_job_queue = 'default-preparation-job-queue'
+      @preparation_job_definition = 'default-preparation-job-definition'
+      @execution_job_queue = 'default-execution-job-queue'
+      @execution_job_definition = 'default-execution-job-definition'
+    end
+  end
+end


### PR DESCRIPTION
# 概要
AWS Batchのジョブを送信するためのモデルを追加

# やったこと
- `AssociationDataDeleter::AwsBatch`を追加
  - AWS Batchに削除準備・実行ジョブを送信するメソッドを利用可能にする
- `AssociationDataDeleter::Config`を追加
  - `config/initializers/association_data_deleter.rb`でパラメータ設定が可能にする
- gemspecに`aws-sdk-batch` gemへの依存関係を追加
  - バージョンを指定しないことでインストール先の制限に合わせたバージョンを使用可能にする

# 使用方法
```ruby
batch = AssociationDataDeleter::AwsBatch.new
batch.submit_preparation_job('test', '1') # 返り値はAWS BatchジョブID
```