### PR TITLE
削除ジョブ作成Actionを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ Put a button for sending AWS Batch jobs.
 ```ruby
 # app/views/sample.slim
 
-# sample button for preparation job
+# sample button for creating deletion job and senging preparation job
 = button_to 'データ削除準備', '/association_data_deleter/deletion_jobs', method: :post, params: { target_id: resource.id, target_type: 'Target' }
 ```

--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ Put a button for sending AWS Batch jobs.
 # app/views/sample.slim
 
 # sample button for creating deletion job and senging preparation job
-= button_to 'データ削除準備', '/association_data_deleter/deletion_jobs', method: :post, params: { target_id: resource.id, target_type: 'Target' }
+= button_to 'データ削除準備', association_data_deleter_engine.deletion_jobs_path, method: :post, params: { target_id: resource.id, target_type: 'Target' }
 ```

--- a/README.md
+++ b/README.md
@@ -27,3 +27,11 @@ AssociationDataDeleter.configure do |config|
   config.execution_job_definition = 'sample-execution-job-definition'
 end
 ```
+
+Put a button for sending AWS Batch jobs.
+```ruby
+# app/views/sample.slim
+
+# sample button for preparation job
+= button_to 'データ削除準備', '/association_data_deleter/deletion_jobs', method: :post, params: { target_id: resource.id, target_type: 'Target' }
+```

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 AssociationDataDeleter::Engine.routes.draw do
   # 名前空間を明示的に指定してルーティングを設定
   scope module: 'association_data_deleter' do
-    resources :deletion_jobs, only: %i(index show)
+    resources :deletion_jobs, only: %i(index show create)
   end
 end 

--- a/lib/association_data_deleter/controllers/deletion_jobs_controller.rb
+++ b/lib/association_data_deleter/controllers/deletion_jobs_controller.rb
@@ -25,7 +25,7 @@ module AssociationDataDeleter
       aws_batch_job_id = batch.submit_preparation_job("preparation_for_job_id_#{@deletion_job.id}", @deletion_job.id.to_s)
       @deletion_job.update(prepare_aws_batch_job_id: aws_batch_job_id)
 
-      redirect_to '/association_data_deleter/deletion_jobs'
+      redirect_to association_data_deleter_engine.deletion_jobs_path
     end
   end
 end 

--- a/lib/association_data_deleter/controllers/deletion_jobs_controller.rb
+++ b/lib/association_data_deleter/controllers/deletion_jobs_controller.rb
@@ -21,7 +21,7 @@ module AssociationDataDeleter
       )
       @deletion_job.save!
 
-      redirect_to @deletion_job
+      redirect_to '/association_data_deleter/deletion_jobs'
     end
   end
 end 

--- a/lib/association_data_deleter/controllers/deletion_jobs_controller.rb
+++ b/lib/association_data_deleter/controllers/deletion_jobs_controller.rb
@@ -21,6 +21,10 @@ module AssociationDataDeleter
       )
       @deletion_job.save!
 
+      batch = AssociationDataDeleter::AwsBatch.new
+      aws_batch_job_id = batch.submit_preparation_job("preparation_for_job_id_#{@deletion_job.id}", @deletion_job.id.to_s)
+      @deletion_job.update(prepare_aws_batch_job_id: aws_batch_job_id)
+
       redirect_to '/association_data_deleter/deletion_jobs'
     end
   end

--- a/lib/association_data_deleter/controllers/deletion_jobs_controller.rb
+++ b/lib/association_data_deleter/controllers/deletion_jobs_controller.rb
@@ -12,5 +12,15 @@ module AssociationDataDeleter
 
       render template: "deletion_jobs/show", layout: 'application'
     end
+
+    def create
+      @deletion_job = AssociationDataDeleter::DeletionJob.new(
+        target_id: params[:target_id],
+        target_type: params[:target_type]
+      )
+      @deletion_job.save!
+
+      redirect_to @deletion_job
+    end
   end
 end 

--- a/lib/association_data_deleter/controllers/deletion_jobs_controller.rb
+++ b/lib/association_data_deleter/controllers/deletion_jobs_controller.rb
@@ -16,7 +16,8 @@ module AssociationDataDeleter
     def create
       @deletion_job = AssociationDataDeleter::DeletionJob.new(
         target_id: params[:target_id],
-        target_type: params[:target_type]
+        target_type: params[:target_type],
+        status: 'preparing'
       )
       @deletion_job.save!
 


### PR DESCRIPTION
# 概要
削除ジョブ作成Actionを追加する

# やったこと
- `DeletionJobsController::create`メソッドの実装
- `config/routes.rb`にcreateメソッドの許可設定を追加
- READMEにデータ削除準備ボタン設置の例を追加