### PR TITLE
削除ジョブ実行Actionを追加

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 AssociationDataDeleter::Engine.routes.draw do
   # 名前空間を明示的に指定してルーティングを設定
   scope module: 'association_data_deleter' do
-    resources :deletion_jobs, only: %i(index show create)
+    resources :deletion_jobs, only: %i(index show create) do
+      post :execute, on: :member
+    end
   end
 end 

--- a/lib/association_data_deleter/controllers/deletion_jobs_controller.rb
+++ b/lib/association_data_deleter/controllers/deletion_jobs_controller.rb
@@ -27,5 +27,17 @@ module AssociationDataDeleter
 
       redirect_to '/association_data_deleter/deletion_jobs'
     end
+
+    def execute
+      @deletion_job = AssociationDataDeleter::DeletionJob.find(params[:id])
+
+      raise AssociationDataDeleter::Error, "削除ジョブID: #{@deletion_job.id} のステータスが'ready'ではないので実行できません" unless @deletion_job.status == 'ready'
+
+      batch = AssociationDataDeleter::AwsBatch.new
+      aws_batch_job_id = batch.submit_execution_job("execution_for_job_id_#{@deletion_job.id}", @deletion_job.id.to_s)
+      @deletion_job.update(delete_aws_batch_job_id: aws_batch_job_id)
+
+      redirect_to association_data_deleter_engine.deletion_job_path(@deletion_job)
+    end
   end
 end 

--- a/lib/association_data_deleter/views/deletion_jobs/index.html.erb
+++ b/lib/association_data_deleter/views/deletion_jobs/index.html.erb
@@ -32,7 +32,7 @@
           <%= link_to "詳細", association_data_deleter_engine.deletion_job_path(job), class: "btn btn-sm btn-info" %>
         </td>
         <td>
-          <%= link_to "実行", association_data_deleter_engine.execute_deletion_job_path(job), { method: "post" }, class: "btn btn-sm btn-info" %>
+          <%= link_to "実行", association_data_deleter_engine.execute_deletion_job_path(job), method: :post, class: "btn btn-sm btn-info" %>
         </td>
       </tr>
     <% end %>

--- a/lib/association_data_deleter/views/deletion_jobs/index.html.erb
+++ b/lib/association_data_deleter/views/deletion_jobs/index.html.erb
@@ -13,6 +13,7 @@
       <th>作成日</th>
       <th>更新日</th>
       <th>詳細</th>
+      <th>削除実行</th>
     </tr>
   </thead>
   <tbody>
@@ -29,6 +30,9 @@
         <td><%= job.updated_at %></td>
         <td>
           <%= link_to "詳細", association_data_deleter_engine.deletion_job_path(job), class: "btn btn-sm btn-info" %>
+        </td>
+        <td>
+          <%= link_to "実行", association_data_deleter_engine.execute_deletion_job_path(job), { method: "post" }, class: "btn btn-sm btn-info" %>
         </td>
       </tr>
     <% end %>

--- a/lib/association_data_deleter/views/deletion_jobs/index.html.erb
+++ b/lib/association_data_deleter/views/deletion_jobs/index.html.erb
@@ -33,7 +33,7 @@
         </td>
         <td>
           <% if job.status == 'ready'  %>
-            <%= link_to "実行", association_data_deleter_engine.execute_deletion_job_path(job), method: :post, class: "btn btn-sm btn-info" %>
+            <%= button_to "実行", association_data_deleter_engine.execute_deletion_job_path(job), method: :post, class: "btn btn-sm btn-info" %>
           <% end %>
         </td>
       </tr>

--- a/lib/association_data_deleter/views/deletion_jobs/index.html.erb
+++ b/lib/association_data_deleter/views/deletion_jobs/index.html.erb
@@ -32,7 +32,9 @@
           <%= link_to "詳細", association_data_deleter_engine.deletion_job_path(job), class: "btn btn-sm btn-info" %>
         </td>
         <td>
-          <%= link_to "実行", association_data_deleter_engine.execute_deletion_job_path(job), method: :post, class: "btn btn-sm btn-info" %>
+          <% if job.status == 'ready'  %>
+            <%= link_to "実行", association_data_deleter_engine.execute_deletion_job_path(job), method: :post, class: "btn btn-sm btn-info" %>
+          <% end %>
         </td>
       </tr>
     <% end %>


### PR DESCRIPTION
# 概要
削除ジョブ実行Actionを追加する

# やったこと
- `DeletionJobsController::execute`メソッドの実装
- `config/routes.rb`にexecuteメソッドの設定を追加
- 削除ジョブ一覧画面に「実行」ボタンを追加