### PR TITLE
<解約企業データ削除処理> 既存レコード確認用メソッドを定義

### DIFF
--- a/lib/association_data_deleter/models/deletion_job.rb
+++ b/lib/association_data_deleter/models/deletion_job.rb
@@ -1,5 +1,9 @@
 module AssociationDataDeleter
   class DeletionJob < ActiveRecord::Base
     has_many :deletion_job_details, dependent: :destroy
+    
+    def self.exists_for_target?(target_id, target_type)
+      exists?(target_id: target_id, target_type: target_type)
+    end
   end
 end


### PR DESCRIPTION
## 概要

既存レコード確認用のクラスメソッドを定義しました。
既にレコードが存在している = 既に「データ削除準備」処理が動作している。
本メソッドを用いることで「データ削除準備」ボタンを連続で押下されないようにします。

使用例)
`AssociationDataDeleter::DeletionJob.exists_for_target?(<id>, <target_type>)`